### PR TITLE
Only style headers directly under #styleguide-content not deeper such…

### DIFF
--- a/styleguide/static/styleguide/styleguide.css
+++ b/styleguide/static/styleguide/styleguide.css
@@ -55,7 +55,7 @@ pre>code.hljs {
 .styleguide-sep>span {
 
 }
-#styleguide-content h4 {
+#styleguide-content > h4 {
     margin-top: 25px;
 }
 .styleguide-status-unstyled::after {


### PR DESCRIPTION
… as in examples themselves