### PR TITLE
Accordion menus

### DIFF
--- a/styleguide/static/styleguide/styleguide.js
+++ b/styleguide/static/styleguide/styleguide.js
@@ -1,0 +1,35 @@
+var toggle = function(el){
+	if (el.classList.contains('open')){
+		el.classList.remove('open')
+	}else{
+		el.classList.add('open')
+	}
+}
+
+// toggle sub_menus
+var toggleMenus = document.getElementsByClassName('toggle-menu')
+Array.prototype.forEach.call(toggleMenus, function(el) {
+	el.onclick = function(){
+		toggle(this)
+	}
+})
+
+var hamburger = document.getElementById('hamburger')
+hamburger.onclick = function(event){
+
+	//toggle button image
+	var src = this.children[0].src,
+		src_array = src.split('/')
+		src_type = src_array[src_array.length - 1].split('.')[0]
+
+	if (src_type == 'hamburger'){
+		this.children[0].src = src.replace('hamburger', 'close')
+	}else{
+		this.children[0].src = src.replace('close', 'hamburger')
+	}
+
+	// toggle nav
+	var nav = document.getElementById('styleguide-menu')
+	toggle(nav)
+}
+

--- a/styleguide/templates/styleguide/styleguide.html
+++ b/styleguide/templates/styleguide/styleguide.html
@@ -13,6 +13,9 @@
     <header id="styleguide-header">
         <div class="styleguide-header-left">
             <img src ="{% static "img/logo4.png" %}">
+            <button id="hamburger">
+                <img class="devices" src ="{% static "img/hamburger.png" %}">
+            </button>
         </div>
         <div class="styleguide-header-right">
             <div class="devices">
@@ -23,16 +26,22 @@
             </div>
         </div>
     </header>
-    <button id="hamburger" class="close">
-        <img class="devices" src ="{% static "img/close.png" %}">
-    </button>
-    <button id="hamburger">
-        <img class="devices" src ="{% static "img/hamburger.png" %}">
-    </button>
     <nav id=styleguide-menu>
         <ul>
-        {% for name, slug in templates %}
-            <li><a href="{% url "styleguide_page" slug %}">{{ name }}</a>
+        {% for name, slug, sub_slugs in templates %}
+            <li>
+                <a href="{% url "styleguide_page" slug %}">{{ name }}</a>
+                {% if sub_slugs %}
+                    <span class="toggle-menu"></span>
+                    <ul class="sub-menu">
+                        {% for s in sub_slugs%}
+                            <li>
+                                <a href="{% url "styleguide_sub_page" slug s %}">{{ s|title }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </li>
         {% endfor %}
     </nav>
     <main>
@@ -47,6 +56,7 @@
     {% block extra-js%}
     <script src="{% static "styleguide/highlightjs/highlight.pack.js" %}"></script>
     <script>hljs.initHighlightingOnLoad();</script>
+    <script src="{% static "styleguide/styleguide.js" %}"></script>
     {% endblock %}
 
 {% endblock %}

--- a/styleguide/templatetags/styleguide_tags.py
+++ b/styleguide/templatetags/styleguide_tags.py
@@ -97,7 +97,8 @@ class ExampleNode(template.Node):
 def get_styleguide_templates():
     """Return tuples of (display name, slug) for found styleguide templates"""
     templates = []
-    for slug in utils.get_styleguide_templates():
+    for slug, sub_slugs in utils.get_styleguide_templates().items():
         name = defaultfilters.title(slug.replace('-', ' '))
-        templates.append((name, slug))
+        templates.append((name, slug, sub_slugs))
+
     return templates

--- a/styleguide/urls.py
+++ b/styleguide/urls.py
@@ -7,4 +7,6 @@ urlpatterns = [
         views.styleguide,
         name='styleguide'),
     url(r'^(?P<name>[0-9A-Za-z_\-]+)/$', views.styleguide_page, name="styleguide_page"),
+    url(r'^(?P<name>[0-9A-Za-z_\-]+)/(?P<sub_page>[0-9A-Za-z_\-]+)/$',
+                views.styleguide_sub_page, name="styleguide_sub_page"),
 ]

--- a/styleguide/utils.py
+++ b/styleguide/utils.py
@@ -7,14 +7,24 @@ def get_styleguide_templates(styleguide_dirs=None):
     """Walk selected directories and pull out valid filenames"""
     if not styleguide_dirs:
         styleguide_dirs = get_styleguide_dirs()
-    template_paths = set()
+    template_paths = {}
+    sub_template_paths = []
     for template_dir in styleguide_dirs:
         for (dirpath, dirnames, filenames) in os.walk(template_dir):
             for filename in filenames:
                 match = re.search(r'^styleguide-([\w-]+)\.html$', filename)
                 if match:
-                    template_paths.add(match.group(1))
-    return sorted(template_paths)
+                    if '-' not in match.group(1):
+                        template_paths[match.group(1)] = []
+                    else:
+                        sub_menu_item = match.group(1).split('-')
+                        sub_template_paths.append(sub_menu_item)
+
+    for sub in sub_template_paths:
+        if sub[0] in template_paths:
+            template_paths[sub[0]].append(sub[1])
+
+    return template_paths
 
 
 def get_styleguide_dirs():

--- a/styleguide/views.py
+++ b/styleguide/views.py
@@ -10,3 +10,7 @@ def styleguide_page(request, name):
     return render(request, "styleguide/styleguide-%s.html" % name, {
 
     })
+def styleguide_sub_page(request, name, sub_page):
+    return render(request, "styleguide/styleguide-%s-%s.html" % (name, sub_page), {
+
+    })


### PR DESCRIPTION
Now grabbing files formatted with two hyphens. e.g. `styleguide-typography-headings.html`.  These templates can be added to the same directory as before and links to these pages will be placed under their parents in submenus.  

Added some vanilla to open and close things.  
